### PR TITLE
Colons do not need to be escaped

### DIFF
--- a/tidy_headers/_main.py
+++ b/tidy_headers/_main.py
@@ -55,8 +55,8 @@ def read(filepath, *, encoding="utf-8"):
 "or generator. Got %s instead." % type(filepath))
     for line in fhd:
         if line[0] == "#":
-            split = re.split("\: |\:\t", line, maxsplit=1)
-            key = split[0][2:]
+            split = re.split(": |:\t", line, maxsplit=1)
+            key = split[0][2:]O
             headers[key] = string2item(split[1])
         else:
             break  # all header lines are at the beginning


### PR DESCRIPTION
```
>>> line = "HI:\tthere: are: many: colons:"
>>> print(line)
HI:	there: are: many: colons:
>>> print("",line)
 HI:	there: are: many: colons:
>>> re.split(": |:\t", line, maxsplit=1)
['HI', 'there: are: many: colons:']
>>> re.split("\: |\:\t", line, maxsplit=1)
['HI', 'there: are: many: colons:']
>>> re.split(r"\: |\:\t", line, maxsplit=1)
['HI', 'there: are: many: colons:']
>>> re.split(": |:\t", line, maxsplit=1)
['HI', 'there: are: many: colons:']
```

Causes a (hidden by default) warning about unexpected escape sequence